### PR TITLE
Update Docker build paths to NekoNet

### DIFF
--- a/Docker/build/Dockerfile-MareSynchronosAuthService
+++ b/Docker/build/Dockerfile-MareSynchronosAuthService
@@ -1,10 +1,10 @@
 FROM mcr.microsoft.com/dotnet/sdk:9.0 as BUILD
 
-COPY MareAPI /server/MareAPI
-COPY MareSynchronosServer/MareSynchronosShared /server/MareSynchronosServer/MareSynchronosShared
-COPY MareSynchronosServer/MareSynchronosAuthService /server/MareSynchronosServer/MareSynchronosAuthService
+COPY NekoNetAPI /server/NekoNetAPI
+COPY NekoNetServer/NekoNetShared /server/NekoNetServer/NekoNetShared
+COPY NekoNetServer/NekoNetAuthService /server/NekoNetServer/NekoNetAuthService
 
-WORKDIR /server/MareSynchronosServer/MareSynchronosAuthService/
+WORKDIR /server/NekoNetServer/NekoNetAuthService/
 
 RUN dotnet publish \
         --configuration=Debug \
@@ -22,11 +22,11 @@ RUN adduser \
         --system \
         mare
 
-COPY --from=BUILD /build /opt/MareSynchronosAuthService
-RUN chown -R mare:mare /opt/MareSynchronosAuthService
+COPY --from=BUILD /build /opt/NekoNetAuthService
+RUN chown -R mare:mare /opt/NekoNetAuthService
 RUN apt-get update; apt-get install curl -y
 
 USER mare:mare
-WORKDIR /opt/MareSynchronosAuthService
+WORKDIR /opt/NekoNetAuthService
 
-CMD ["./MareSynchronosAuthService"]
+CMD ["./NekoNetAuthService"]

--- a/Docker/build/Dockerfile-MareSynchronosServer
+++ b/Docker/build/Dockerfile-MareSynchronosServer
@@ -1,10 +1,10 @@
 FROM mcr.microsoft.com/dotnet/sdk:9.0 as BUILD
 
-COPY MareAPI /server/MareAPI
-COPY MareSynchronosServer/MareSynchronosShared /server/MareSynchronosServer/MareSynchronosShared
-COPY MareSynchronosServer/MareSynchronosServer /server/MareSynchronosServer/MareSynchronosServer
+COPY NekoNetAPI /server/NekoNetAPI
+COPY NekoNetServer/NekoNetShared /server/NekoNetServer/NekoNetShared
+COPY NekoNetServer/NekoNetServer /server/NekoNetServer/NekoNetServer
 
-WORKDIR /server/MareSynchronosServer/MareSynchronosServer/
+WORKDIR /server/NekoNetServer/NekoNetServer/
 
 RUN dotnet publish \
         --configuration=Release \
@@ -22,11 +22,11 @@ RUN adduser \
         --system \
         mare
 
-COPY --from=BUILD /build /opt/MareSynchronosServer
-RUN chown -R mare:mare /opt/MareSynchronosServer
+COPY --from=BUILD /build /opt/NekoNetServer
+RUN chown -R mare:mare /opt/NekoNetServer
 RUN apt-get update; apt-get install curl -y
 
 USER mare:mare
-WORKDIR /opt/MareSynchronosServer
+WORKDIR /opt/NekoNetServer
 
-CMD ["./MareSynchronosServer"]
+CMD ["./NekoNetServer"]

--- a/Docker/build/Dockerfile-MareSynchronosServices
+++ b/Docker/build/Dockerfile-MareSynchronosServices
@@ -1,10 +1,10 @@
 FROM mcr.microsoft.com/dotnet/sdk:9.0 as BUILD
 
-COPY MareAPI /server/MareAPI
-COPY MareSynchronosServer/MareSynchronosShared /server/MareSynchronosServer/MareSynchronosShared
-COPY MareSynchronosServer/MareSynchronosServices /server/MareSynchronosServer/MareSynchronosServices
+COPY NekoNetAPI /server/NekoNetAPI
+COPY NekoNetServer/NekoNetShared /server/NekoNetServer/NekoNetShared
+COPY NekoNetServer/NekoNetServices /server/NekoNetServer/NekoNetServices
 
-WORKDIR /server/MareSynchronosServer/MareSynchronosServices/
+WORKDIR /server/NekoNetServer/NekoNetServices/
 
 RUN dotnet publish \
         --configuration=Debug \
@@ -22,11 +22,11 @@ RUN adduser \
         --system \
         mare
 
-COPY --from=BUILD /build /opt/MareSynchronosServices
-RUN chown -R mare:mare /opt/MareSynchronosServices
+COPY --from=BUILD /build /opt/NekoNetServices
+RUN chown -R mare:mare /opt/NekoNetServices
 RUN apt-get update; apt-get install curl -y
 
 USER mare:mare
-WORKDIR /opt/MareSynchronosServices
+WORKDIR /opt/NekoNetServices
 
-CMD ["./MareSynchronosServices"]
+CMD ["./NekoNetServices"]

--- a/Docker/build/Dockerfile-MareSynchronosStaticFilesServer
+++ b/Docker/build/Dockerfile-MareSynchronosStaticFilesServer
@@ -1,10 +1,10 @@
 FROM mcr.microsoft.com/dotnet/sdk:9.0 as BUILD
 
-COPY MareAPI /server/MareAPI
-COPY MareSynchronosServer/MareSynchronosShared /server/MareSynchronosServer/MareSynchronosShared
-COPY MareSynchronosServer/MareSynchronosStaticFilesServer /server/MareSynchronosServer/MareSynchronosStaticFilesServer
+COPY NekoNetAPI /server/NekoNetAPI
+COPY NekoNetServer/NekoNetShared /server/NekoNetServer/NekoNetShared
+COPY NekoNetServer/NekoNetStaticFilesServer /server/NekoNetServer/NekoNetStaticFilesServer
 
-WORKDIR /server/MareSynchronosServer/MareSynchronosStaticFilesServer/
+WORKDIR /server/NekoNetServer/NekoNetStaticFilesServer/
 
 RUN dotnet publish \
         --configuration=Release \
@@ -22,11 +22,11 @@ RUN adduser \
         --system \
         mare
 
-COPY --from=BUILD /build /opt/MareSynchronosStaticFilesServer
-RUN chown -R mare:mare /opt/MareSynchronosStaticFilesServer
+COPY --from=BUILD /build /opt/NekoNetStaticFilesServer
+RUN chown -R mare:mare /opt/NekoNetStaticFilesServer
 RUN apt-get update; apt-get install curl -y
 
 USER mare:mare
-WORKDIR /opt/MareSynchronosStaticFilesServer
+WORKDIR /opt/NekoNetStaticFilesServer
 
-CMD ["./MareSynchronosStaticFilesServer"]
+CMD ["./NekoNetStaticFilesServer"]


### PR DESCRIPTION
## Summary
- update Docker build stages to copy NekoNet source folders instead of MareSynchronos ones
- adjust runtime work directories, install paths, and entrypoints to use the new NekoNet names

