### PR TITLE
Fix docker build context ordering

### DIFF
--- a/Docker/build/linux-git/docker-build-authservice.sh
+++ b/Docker/build/linux-git/docker-build-authservice.sh
@@ -1,2 +1,10 @@
 #!/bin/sh
-docker build -t darkarchon/mare-synchronos-authservice:latest . -f ../Dockerfile-MareSynchronosAuthService-git --no-cache --pull --force-rm
+set -e
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+docker build -t darkarchon/mare-synchronos-authservice:latest \
+  -f "$REPO_ROOT/Docker/build/Dockerfile-MareSynchronosAuthService-git" \
+  --no-cache --pull --force-rm \
+  "$REPO_ROOT"

--- a/Docker/build/linux-git/docker-build-server.sh
+++ b/Docker/build/linux-git/docker-build-server.sh
@@ -1,2 +1,10 @@
 #!/bin/sh
-docker build -t darkarchon/mare-synchronos-server:latest . -f ../Dockerfile-MareSynchronosServer-git --no-cache --pull --force-rm
+set -e
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+docker build -t darkarchon/mare-synchronos-server:latest \
+  -f "$REPO_ROOT/Docker/build/Dockerfile-MareSynchronosServer-git" \
+  --no-cache --pull --force-rm \
+  "$REPO_ROOT"

--- a/Docker/build/linux-git/docker-build-services.sh
+++ b/Docker/build/linux-git/docker-build-services.sh
@@ -1,2 +1,10 @@
 #!/bin/sh
-docker build -t darkarchon/mare-synchronos-services:latest . -f ../Dockerfile-MareSynchronosServices-git --no-cache --pull --force-rm
+set -e
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+docker build -t darkarchon/mare-synchronos-services:latest \
+  -f "$REPO_ROOT/Docker/build/Dockerfile-MareSynchronosServices-git" \
+  --no-cache --pull --force-rm \
+  "$REPO_ROOT"

--- a/Docker/build/linux-git/docker-build-staticfilesserver.sh
+++ b/Docker/build/linux-git/docker-build-staticfilesserver.sh
@@ -1,2 +1,10 @@
 #!/bin/sh
-docker build -t darkarchon/mare-synchronos-staticfilesserver:latest . -f ../Dockerfile-MareSynchronosStaticFilesServer-git --no-cache --pull --force-rm
+set -e
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+docker build -t darkarchon/mare-synchronos-staticfilesserver:latest \
+  -f "$REPO_ROOT/Docker/build/Dockerfile-MareSynchronosStaticFilesServer-git" \
+  --no-cache --pull --force-rm \
+  "$REPO_ROOT"

--- a/Docker/build/linux-local/docker-build-authservice.sh
+++ b/Docker/build/linux-local/docker-build-authservice.sh
@@ -1,2 +1,10 @@
 #!/bin/sh
-docker build -t darkarchon/mare-synchronos-authservice:latest . -f ../Dockerfile-MareSynchronosAuthService --no-cache --pull --force-rm
+set -e
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+docker build -t darkarchon/mare-synchronos-authservice:latest \
+  -f "$REPO_ROOT/Docker/build/Dockerfile-MareSynchronosAuthService" \
+  --no-cache --pull --force-rm \
+  "$REPO_ROOT"

--- a/Docker/build/linux-local/docker-build-server.sh
+++ b/Docker/build/linux-local/docker-build-server.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
-cd ../../../
-docker build -t darkarchon/mare-synchronos-server:latest . -f ../Dockerfile-MareSynchronosServer --no-cache --pull --force-rm
-cd Docker/build/linux-local
+set -e
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+docker build -t darkarchon/mare-synchronos-server:latest \
+  -f "$REPO_ROOT/Docker/build/Dockerfile-MareSynchronosServer" \
+  --no-cache --pull --force-rm \
+  "$REPO_ROOT"

--- a/Docker/build/linux-local/docker-build-services.sh
+++ b/Docker/build/linux-local/docker-build-services.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
-cd ../../../
-docker build -t darkarchon/mare-synchronos-services:latest . -f ../Dockerfile-MareSynchronosServices --no-cache --pull --force-rm
-cd Docker/build/linux-local
+set -e
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+docker build -t darkarchon/mare-synchronos-services:latest \
+  -f "$REPO_ROOT/Docker/build/Dockerfile-MareSynchronosServices" \
+  --no-cache --pull --force-rm \
+  "$REPO_ROOT"

--- a/Docker/build/linux-local/docker-build-staticfilesserver.sh
+++ b/Docker/build/linux-local/docker-build-staticfilesserver.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
-cd ../../../
-docker build -t darkarchon/mare-synchronos-staticfilesserver:latest . -f ../Dockerfile-MareSynchronosStaticFilesServer --no-cache --pull --force-rm
-cd Docker/build/linux-local
+set -e
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+docker build -t darkarchon/mare-synchronos-staticfilesserver:latest \
+  -f "$REPO_ROOT/Docker/build/Dockerfile-MareSynchronosStaticFilesServer" \
+  --no-cache --pull --force-rm \
+  "$REPO_ROOT"


### PR DESCRIPTION
## Summary
- compute the repository root once in each Linux local build helper and pass it as the docker build context after all flags
- apply the same repo-root aware ordering to the Linux git helper scripts so the context argument trails the flags

